### PR TITLE
Mad 928:  Stop the customTabs from closing on Sign-in Page

### DIFF
--- a/simple_auth_flutter/android/src/main/java/clancey/simpleauth/simpleauthflutter/CustomTabsAuthenticator.java
+++ b/simple_auth_flutter/android/src/main/java/clancey/simpleauth/simpleauthflutter/CustomTabsAuthenticator.java
@@ -41,7 +41,7 @@ public class CustomTabsAuthenticator {
         CustomTabsIntent intent = builder.build();
         final Uri uri =  Uri.parse(authenticator.initialUrl);
 
-        intent.intent.addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP | Intent.FLAG_ACTIVITY_NO_HISTORY | Intent.FLAG_ACTIVITY_NEW_TASK);
+        intent.intent.addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP | Intent.FLAG_ACTIVITY_NEW_TASK);
         Intent keepAliveIntent = new Intent().setClassName(
                 activity.getPackageName(), KeepAliveService.class.getCanonicalName());
         intent.intent.putExtra("android.support.customtabs.extra.KEEP_ALIVE", keepAliveIntent);

--- a/simple_auth_flutter/android/src/main/java/clancey/simpleauth/simpleauthflutter/CustomTabsAuthenticator.java
+++ b/simple_auth_flutter/android/src/main/java/clancey/simpleauth/simpleauthflutter/CustomTabsAuthenticator.java
@@ -41,7 +41,7 @@ public class CustomTabsAuthenticator {
         CustomTabsIntent intent = builder.build();
         final Uri uri =  Uri.parse(authenticator.initialUrl);
 
-        intent.intent.addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP | Intent.FLAG_ACTIVITY_NEW_TASK);
+        intent.intent.addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP | Intent.FLAG_ACTIVITY_NO_HISTORY | Intent.FLAG_ACTIVITY_NEW_TASK);
         Intent keepAliveIntent = new Intent().setClassName(
                 activity.getPackageName(), KeepAliveService.class.getCanonicalName());
         intent.intent.putExtra("android.support.customtabs.extra.KEEP_ALIVE", keepAliveIntent);

--- a/simple_auth_flutter/android/src/main/java/clancey/simpleauth/simpleauthflutter/SimpleAuthFlutterPlugin.java
+++ b/simple_auth_flutter/android/src/main/java/clancey/simpleauth/simpleauthflutter/SimpleAuthFlutterPlugin.java
@@ -30,17 +30,6 @@ public class SimpleAuthFlutterPlugin implements FlutterPlugin, ActivityAware,Met
   private MethodChannel methodChannel;
   private EventChannel eventChannel;
 
-  private MethodChannel channel;
-  @Override
-  public void onAttachedToEngine(@NonNull FlutterPluginBinding flutterPluginBinding) {
-    channel = new MethodChannel(flutterPluginBinding.getBinaryMessenger(), "simple_auth_flutter/showAuthenticator");
-    final EventChannel eventChannel =
-            new EventChannel(registrar.messenger(), "simple_auth_flutter/urlChanged");
-    eventChannel.setStreamHandler(this);
-    channel.setMethodCallHandler(this);
-
-  }
-
 
   @Override
   public void onMethodCall(MethodCall call, Result result)   {


### PR DESCRIPTION
simple_auth_flutter/CustamTabsAuthenticator.java : removed the `Intent.FLAG_ACTIVITY_NO_HISTORY`
simple_auth_flutter/SimpleAuthFlutterPlugin.java: removed the block of code causing error because it has duplicates `onAttachedToEngine`